### PR TITLE
Fix library build: register twzipcode-data locales as dynamic require…

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -28,6 +28,16 @@ export default defineConfig({
         }
       }
     },
+    commonjsOptions: {
+      // twzipcode-data loads its locale data via a computed dynamic require
+      // (`require('./' + locale + '/counties')`). Rollup cannot resolve that
+      // statically, so register the locale data files as dynamic require
+      // targets, otherwise components render no data at runtime.
+      dynamicRequireTargets: [
+        'node_modules/twzipcode-data/dist/*/counties.js',
+        'node_modules/twzipcode-data/dist/*/zipcodes.js'
+      ]
+    },
     sourcemap: true
   },
   test: {


### PR DESCRIPTION
… targets

The library build bundles twzipcode-data, which loads its locale data via a computed dynamic require (require('./' + locale + '/counties')). Rollup cannot resolve that statically, so the published bundle threw 'Could not dynamically require' at runtime and components rendered no data. Configure commonjsOptions.dynamicRequireTargets for the locale data files, mirroring the demo build fix.