### PR TITLE
Move vue to peerDependencies and add README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 [![Coverage Status](https://coveralls.io/repos/github/yyc1217/twzipcode-vue/badge.svg?branch=master)](https://coveralls.io/github/yyc1217/twzipcode-vue?branch=master)
 [![npm](https://img.shields.io/npm/dt/twzipcode-vue.svg)](https://www.npmjs.com/package/twzipcode-vue)
 [![npm](https://img.shields.io/npm/v/twzipcode-vue.svg)](https://www.npmjs.com/package/twzipcode-vue)
+[![minzipped size](https://img.shields.io/bundlephobia/minzip/twzipcode-vue)](https://bundlephobia.com/package/twzipcode-vue)
+[![install size](https://packagephobia.com/badge?p=twzipcode-vue)](https://packagephobia.com/result?p=twzipcode-vue)
+[![Vue](https://img.shields.io/npm/dependency-version/twzipcode-vue/peer/vue)](https://vuejs.org/)
 [![npm](https://img.shields.io/npm/l/twzipcode-vue.svg)]()
 [![GitHub stars](https://img.shields.io/github/stars/yyc1217/twzipcode-vue.svg?style=social&label=Star)]()
 

--- a/package.json
+++ b/package.json
@@ -41,10 +41,12 @@
     "url": "https://github.com/yyc1217/twzipcode-vue/issues"
   },
   "license": "MIT",
+  "peerDependencies": {
+    "vue": "^3.0.0"
+  },
   "dependencies": {
     "lodash": "^4.17.21",
-    "twzipcode-data": "^2.0.0",
-    "vue": "^3.5.13"
+    "twzipcode-data": "^2.0.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.1",
@@ -54,6 +56,7 @@
     "sass": "^1.83.4",
     "should": "^13.2.3",
     "vite": "^6.0.11",
-    "vitest": "^3.0.5"
+    "vitest": "^3.0.5",
+    "vue": "^3.5.13"
   }
 }


### PR DESCRIPTION
## 1. Move `vue` to peerDependencies
A Vue component library should not bundle its own copy of Vue — consumers provide it. Moved `vue` from `dependencies` to `peerDependencies` (`^3.0.0`). It stays in `devDependencies` (`^3.5.13`) so the repo's own build and tests still run.

This also makes the new Vue peer-version badge meaningful.

## 2. README badges
Added three informative badges next to the existing ones:
- **minzipped size** (bundlephobia) — published bundle size
- **install size** (packagephobia) — install footprint
- **Vue** (`npm/dependency-version/.../peer/vue`) — the supported Vue version, read from peerDependencies

Per request, did **not** add the `last commit` or `PRs welcome` badges.

## Verification
- `yarn test`: 43 passed.
- `yarn build`: succeeds; both `dist/twzipcode.es.js` and `dist/twzipcode.umd.js` import `vue` as an external (not bundled) — confirmed Vue internals are not inlined.
- `package.json` valid; `yarn install` resolves cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_015v4d4Sqaf4JHCA9S9bGjGq)_