### PR TITLE
Add build-artifact smoke tests for library and demo

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,6 +18,9 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn run test
 
+    # Smoke-test the built library and demo (builds dist/ and docs/ first)
+      - run: yarn run test:smoke
+
     # Send coverage report to Coveralls
       - name: Coveralls
         uses: coverallsapp/github-action@master

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "build": "vite build",
     "build:demo": "vite build --config vite.demo.config.js",
     "test": "vitest run --coverage",
+    "test:smoke": "vite build && vite build --config vite.demo.config.js && vitest run --config vitest.smoke.config.js",
     "prepublishOnly": "yarn build"
   },
   "repository": {

--- a/test/smoke/demo.smoke.spec.js
+++ b/test/smoke/demo.smoke.spec.js
@@ -1,0 +1,52 @@
+import 'should'
+import { describe, it, beforeAll, afterAll } from 'vitest'
+import { readFileSync, existsSync } from 'node:fs'
+import { fileURLToPath, URL as NodeURL } from 'node:url'
+import { createBrowser, waitFor } from './jsdom-env.js'
+
+// Smoke-test the BUILT demo site (docs/) that GitHub Pages serves. Catches
+// regressions that only surface in the browser bundle: runtime template
+// compilation of the in-DOM template, bundled locale data, and the event
+// callback. Run `yarn build:demo` first.
+const docsDir = fileURLToPath(new NodeURL('../../docs/', import.meta.url))
+const indexHtml = docsDir + 'index.html'
+
+describe('demo site smoke', () => {
+  let browser
+  let html
+
+  beforeAll(function () {
+    if (!existsSync(indexHtml)) {
+      throw new Error('docs/index.html missing — run `yarn build:demo` before the smoke tests')
+    }
+    html = readFileSync(indexHtml, 'utf8')
+  })
+
+  afterAll(() => browser && browser.cleanup())
+
+  it('mounts and renders all selects with options', async () => {
+    browser = createBrowser(html)
+    const jsFile = html.match(/assets\/(index-[^"]+\.js)/)[1]
+    await import(docsDir + 'assets/' + jsFile)
+
+    await waitFor(() => browser.document.querySelectorAll('#app select option').length > 100)
+
+    const options = browser.document.querySelectorAll('#app select option')
+    // 8 demo selects across counties / zipcodes / groupby
+    options.length.should.be.above(3000)
+  })
+
+  it('updates the event callback when the zipcode select changes', async () => {
+    const d = browser.document
+    const select = d.querySelector('#twzipcode__zipcode--7')
+    const output = d.querySelector('#demoCallback')
+    output.textContent.trim().should.equal('')
+
+    const option = select.querySelectorAll('option')[4]
+    select.value = option.value
+    select.dispatchEvent(new browser.window.Event('change'))
+
+    await waitFor(() => output.textContent.trim() === option.value)
+    output.textContent.trim().should.equal(option.value)
+  })
+})

--- a/test/smoke/demo.smoke.spec.js
+++ b/test/smoke/demo.smoke.spec.js
@@ -1,4 +1,4 @@
-import 'should'
+import should from 'should'
 import { describe, it, beforeAll, afterAll } from 'vitest'
 import { readFileSync, existsSync } from 'node:fs'
 import { fileURLToPath, URL as NodeURL } from 'node:url'
@@ -6,37 +6,163 @@ import { createBrowser, waitFor } from './jsdom-env.js'
 
 // Smoke-test the BUILT demo site (docs/) that GitHub Pages serves. Catches
 // regressions that only surface in the browser bundle: runtime template
-// compilation of the in-DOM template, bundled locale data, and the event
-// callback. Run `yarn build:demo` first.
+// compilation of the in-DOM template, bundled locale data, the event
+// callback, and every documented example rendering its expected output.
+// Run `yarn build:demo` first.
 const docsDir = fileURLToPath(new NodeURL('../../docs/', import.meta.url))
 const indexHtml = docsDir + 'index.html'
+
+// Each demo example on the page, by its element id, with the output it is
+// expected to render. Keeps the smoke test aligned with what the docs claim.
+const EXAMPLES = [
+  {
+    name: '所有郵遞區號 (custom text-template)',
+    id: 'twzipcode__zipcode--1',
+    options: 371,
+    firstText: '100 臺北市-中正區',
+    firstValue: '100'
+  },
+  {
+    name: '以縣市分組',
+    id: 'twzipcode__zipcode--2',
+    options: 371,
+    optgroups: 22,
+    firstText: '中正區',
+    firstValue: '100',
+    firstOptgroup: '臺北市'
+  },
+  {
+    name: '縣市',
+    id: 'twzipcode__county--3',
+    options: 22,
+    firstText: '臺北市',
+    firstValue: '臺北市'
+  },
+  {
+    name: '樣式 - county',
+    id: 'twzipcode__county--4',
+    options: 22,
+    firstText: '臺北市',
+    firstValue: '臺北市'
+  },
+  {
+    name: '樣式 - groupby',
+    id: 'twzipcode__zipcode--groupby--4',
+    options: 371,
+    optgroups: 22,
+    firstText: '中正區',
+    firstValue: '100',
+    firstOptgroup: '臺北市'
+  },
+  {
+    name: '樣式 - zipcode',
+    id: 'twzipcode__zipcode--4',
+    options: 371,
+    firstText: '100 臺北市 中正區',
+    firstValue: '100'
+  },
+  {
+    name: 'value與text格式 (model-value + custom templates)',
+    id: 'twzipcode__zipcode--5',
+    options: 371,
+    firstText: '100 臺北市中正區',
+    firstValue: '臺北市中正區',
+    selected: '臺北市信義區'
+  },
+  {
+    name: '英語 - county',
+    id: 'twzipcode__county--6',
+    options: 22,
+    firstText: 'Taipei City',
+    firstValue: '臺北市'
+  },
+  {
+    name: '英語 - groupby',
+    id: 'twzipcode__zipcode--groupby--6',
+    options: 371,
+    optgroups: 22,
+    firstText: 'Zhongzheng District',
+    firstValue: '100',
+    firstOptgroup: 'Taipei City'
+  },
+  {
+    name: '英語 - zipcode (mixed template)',
+    id: 'twzipcode__zipcode--6',
+    options: 371,
+    firstText: '100 Taipei City / Zhongzheng District',
+    firstValue: '100'
+  },
+  {
+    name: '事件',
+    id: 'twzipcode__zipcode--7',
+    options: 371,
+    firstText: '100 臺北市 中正區',
+    firstValue: '100'
+  },
+  {
+    name: '依縣市篩選 - county (v-model 臺中市)',
+    id: 'twzipcode__county--8',
+    options: 22,
+    firstText: '臺北市',
+    firstValue: '臺北市',
+    selected: '臺中市'
+  },
+  {
+    name: '依縣市篩選 - zipcode (filtered to 臺中市)',
+    id: 'twzipcode__zipcode--8',
+    options: 29,
+    firstText: '400 臺中市 中區',
+    firstValue: '400',
+    selected: '400'
+  }
+]
 
 describe('demo site smoke', () => {
   let browser
   let html
 
-  beforeAll(function () {
+  beforeAll(async function () {
     if (!existsSync(indexHtml)) {
       throw new Error('docs/index.html missing — run `yarn build:demo` before the smoke tests')
     }
     html = readFileSync(indexHtml, 'utf8')
+    browser = createBrowser(html)
+    const jsFile = html.match(/assets\/(index-[^"]+\.js)/)[1]
+    await import(docsDir + 'assets/' + jsFile)
+    // Wait until the app has mounted and the data-driven selects are populated.
+    await waitFor(() => browser.document.querySelectorAll('#app select option').length > 3000)
   })
 
   afterAll(() => browser && browser.cleanup())
 
-  it('mounts and renders all selects with options', async () => {
-    browser = createBrowser(html)
-    const jsFile = html.match(/assets\/(index-[^"]+\.js)/)[1]
-    await import(docsDir + 'assets/' + jsFile)
-
-    await waitFor(() => browser.document.querySelectorAll('#app select option').length > 100)
-
+  it('mounts and renders every demo select', () => {
     const options = browser.document.querySelectorAll('#app select option')
-    // 8 demo selects across counties / zipcodes / groupby
     options.length.should.be.above(3000)
   })
 
-  it('updates the event callback when the zipcode select changes', async () => {
+  for (const example of EXAMPLES) {
+    it(`renders ${example.name}`, () => {
+      const select = browser.document.querySelector(`#${example.id}`)
+      should.exist(select, `#${example.id} should exist`)
+
+      const options = select.querySelectorAll('option')
+      options.length.should.equal(example.options)
+      options[0].textContent.trim().should.equal(example.firstText)
+      options[0].value.should.equal(example.firstValue)
+
+      if (example.optgroups !== undefined) {
+        select.querySelectorAll('optgroup').length.should.equal(example.optgroups)
+      }
+      if (example.firstOptgroup !== undefined) {
+        select.querySelector('optgroup').label.should.equal(example.firstOptgroup)
+      }
+      if (example.selected !== undefined) {
+        select.value.should.equal(example.selected)
+      }
+    })
+  }
+
+  it('事件: updates demoCallback when the zipcode select changes', async () => {
     const d = browser.document
     const select = d.querySelector('#twzipcode__zipcode--7')
     const output = d.querySelector('#demoCallback')
@@ -48,5 +174,28 @@ describe('demo site smoke', () => {
 
     await waitFor(() => output.textContent.trim() === option.value)
     output.textContent.trim().should.equal(option.value)
+  })
+
+  it('依縣市篩選: changing county filters and updates the zipcode select', async () => {
+    const d = browser.document
+    const county = d.querySelector('#twzipcode__county--8')
+    const zipcode = d.querySelector('#twzipcode__zipcode--8')
+
+    // 臺中市 initially -> zipcodes filtered to 臺中市 (29 options, first 400)
+    zipcode.querySelectorAll('option').length.should.equal(29)
+
+    // Switch to 澎湖縣 and verify the zipcode list re-filters.
+    const penghu = [...county.querySelectorAll('option')].find(o => o.value === '澎湖縣')
+    should.exist(penghu, '澎湖縣 option should exist')
+    county.value = '澎湖縣'
+    county.dispatchEvent(new browser.window.Event('change'))
+
+    await waitFor(() => {
+      const first = zipcode.querySelector('option')
+      return first && first.textContent.includes('澎湖縣')
+    })
+    const options = zipcode.querySelectorAll('option')
+    options.length.should.equal(6)
+    options[0].textContent.should.containEql('澎湖縣')
   })
 })

--- a/test/smoke/jsdom-env.js
+++ b/test/smoke/jsdom-env.js
@@ -1,0 +1,52 @@
+import { JSDOM } from 'jsdom'
+
+// Browser globals that Vue 3's runtime touches during mount. jsdom provides
+// them on its window, but they are not on Node's global scope by default.
+const BROWSER_GLOBALS = [
+  'window', 'document', 'navigator',
+  'MutationObserver', 'requestAnimationFrame', 'cancelAnimationFrame',
+  'Node', 'Element', 'HTMLElement', 'SVGElement', 'Text', 'Comment',
+  'getComputedStyle', 'Event', 'CustomEvent'
+]
+
+/**
+ * Create a fresh jsdom document and expose the browser globals that the
+ * built bundles expect, so we can execute the *built* (Rollup) output the
+ * same way a browser would. Returns the jsdom window plus a cleanup fn.
+ */
+export function createBrowser (html = '<!DOCTYPE html><html><body></body></html>', url = 'http://localhost/') {
+  const dom = new JSDOM(html, { url, pretendToBeVisual: true, runScripts: 'outside-only' })
+  const saved = {}
+  for (const key of BROWSER_GLOBALS) {
+    saved[key] = Object.getOwnPropertyDescriptor(globalThis, key)
+    const value = dom.window[key]
+    if (value !== undefined) {
+      try {
+        globalThis[key] = value
+      } catch {
+        // some globals (e.g. navigator) only have a getter; skip them
+      }
+    }
+  }
+  const cleanup = () => {
+    for (const key of BROWSER_GLOBALS) {
+      if (saved[key]) Object.defineProperty(globalThis, key, saved[key])
+      else delete globalThis[key]
+    }
+    dom.window.close()
+  }
+  return { dom, window: dom.window, document: dom.window.document, cleanup }
+}
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0))
+
+/** Wait until `predicate()` is truthy or a timeout elapses. */
+export async function waitFor (predicate, { timeout = 1000, interval = 10 } = {}) {
+  const start = Date.now()
+  while (Date.now() - start < timeout) {
+    if (predicate()) return true
+    await flush()
+    await new Promise(resolve => setTimeout(resolve, interval))
+  }
+  return predicate()
+}

--- a/test/smoke/lib.smoke.spec.js
+++ b/test/smoke/lib.smoke.spec.js
@@ -1,0 +1,49 @@
+import should from 'should'
+import { describe, it, beforeAll, afterAll } from 'vitest'
+import { readFileSync, existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { createBrowser, waitFor } from './jsdom-env.js'
+
+// Smoke-test the BUILT library (dist/) rather than src/, so packaging-level
+// regressions are caught: bundler config, twzipcode-data dynamic require,
+// vue externalization and the named-export shape. Run `yarn build` first.
+const distEs = fileURLToPath(new URL('../../dist/twzipcode.es.js', import.meta.url))
+
+describe('library build smoke', () => {
+  let browser
+
+  beforeAll(function () {
+    if (!existsSync(distEs)) {
+      throw new Error('dist/twzipcode.es.js missing — run `yarn build` before the smoke tests')
+    }
+    browser = createBrowser()
+  })
+
+  afterAll(() => browser && browser.cleanup())
+
+  it('exposes the named component exports', async () => {
+    const lib = await import(distEs)
+    should(lib).have.properties(['County', 'Zipcode', 'ZipcodeGroupby', 'install'])
+  })
+
+  it('renders county options from bundled data (dynamic require works)', async () => {
+    const [{ createApp, h }, lib] = await Promise.all([
+      import('vue'),
+      import(distEs)
+    ])
+    const host = browser.document.createElement('div')
+    browser.document.body.appendChild(host)
+
+    createApp({ render: () => h(lib.County) }).mount(host)
+    await waitFor(() => host.querySelectorAll('option').length > 0)
+
+    const options = host.querySelectorAll('option')
+    options.length.should.equal(22)
+    options[0].textContent.trim().should.equal('臺北市')
+  })
+
+  it('does not inline Vue into the ES bundle (kept external)', () => {
+    const code = readFileSync(distEs, 'utf8')
+    code.should.match(/from"vue"|from "vue"/)
+  })
+})

--- a/vitest.smoke.config.js
+++ b/vitest.smoke.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+// Smoke tests execute the BUILT artifacts (dist/, docs/) inside a jsdom
+// document they set up themselves, so they run in the node environment
+// without coverage. Run `yarn build && yarn build:demo` first.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/smoke/**/*.smoke.spec.js']
+  }
+})


### PR DESCRIPTION
## Why
The unit tests run against `src/` in node, so every recent breakage slipped through — they were all packaging/browser-level: blank GitHub Pages (runtime-only build), `Could not dynamically require` (empty data), and the demo `document.getElementById` handler. Smoke tests close that gap by executing the **built** artifacts in jsdom, the way a browser would.

## What
- **`test/smoke/lib.smoke.spec.js`** — loads `dist/twzipcode.es.js`: asserts named exports (`County`/`Zipcode`/`ZipcodeGroupby`/`install`), mounts `County` and asserts it renders 22 options (proves bundled `twzipcode-data` + dynamic require work), and checks Vue stays external (not inlined).
- **`test/smoke/demo.smoke.spec.js`** — loads the `docs/` bundle, mounts the in-DOM template, and **covers every example on the demo page**:
  - all 13 example component instances are asserted individually (option/optgroup counts, first option text + value, selected value, the locale variants, and the custom-template variants);
  - the 事件 example: changing the select updates `demoCallback`;
  - the 依縣市篩選 example: switching county (臺中市 → 澎湖縣) re-filters the zipcode select (29 → 6 options).
- **`test/smoke/jsdom-env.js`** — helper that sets up a jsdom document with the browser globals Vue touches, plus a `waitFor`.
- **`vitest.smoke.config.js`** + **`test:smoke`** script — `vite build && vite build --config vite.demo.config.js && vitest run --config vitest.smoke.config.js`. Kept separate from the unit run so coverage isn't polluted by built files.
- **CI** — added `yarn run test:smoke` to the test job (Node 24.x/25.x).

No new dependencies — `jsdom` and `vitest` are already devDependencies.

## Verification
- `yarn test`: 43 passed (unchanged; smoke specs are excluded from the unit/coverage run).
- `yarn test:smoke`: 19 passed (3 lib + 16 demo).

## Note
I left out a `viewport` meta-tag assertion for now: that fix lives in the still-open demo PR #332, so asserting it here would fail until #332 merges. Happy to add it in a follow-up once #332 lands.