### PR TITLE
CI: bump actions to Node.js 24-native versions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -2,13 +2,18 @@ name: Test, Publish, & Release
 
 on: [push]
 
+# Force JavaScript actions onto Node.js 24 so any action still bundling the
+# deprecated Node.js 20 runtime (e.g. coverallsapp/github-action) runs on 24.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
 
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: yarn
@@ -24,8 +29,8 @@ jobs:
       matrix:
         node-version: [24.x, 25.x]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
@@ -37,7 +42,7 @@ jobs:
 
     # Send coverage report to Coveralls
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: './test/coverage/lcov.info'
@@ -47,8 +52,8 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/


### PR DESCRIPTION
## Why
GitHub Actions warned that the workflow's actions still bundle the deprecated Node.js 20 runtime:
> Node.js 20 actions are deprecated ... Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

## Changes
- **actions/checkout** `@v4` → `@v5` (runs on Node.js 24 since v5)
- **actions/setup-node** `@v4` → `@v5` (runs on Node.js 24 since v5)
- **coverallsapp/github-action** `@master` → `@v2` — pins to a stable major tag instead of tracking an unversioned branch (more reproducible, and the current v2.x is the maintained line)
- Set **`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`** at the workflow level as a safeguard, so any action still shipping the Node 20 runtime is forced onto Node 24 now (per GitHub's recommendation).

## Verification
- YAML validated (parses cleanly).
- No logic change to the jobs — only action versions and the runtime env var. The lint/test/publish jobs and their dependencies are unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_015v4d4Sqaf4JHCA9S9bGjGq)_