### PR TITLE
CI: publish with npm instead of yarn to fix 404 on publish

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -59,6 +59,9 @@ jobs:
           registry-url: https://registry.npmjs.org/
           cache: yarn
       - run: yarn install --frozen-lockfile
-      - run: yarn publish
+      # Use `npm publish`: it reads NODE_AUTH_TOKEN from the .npmrc that
+      # setup-node generates. `yarn publish` (classic) ignores that token and
+      # publishes unauthenticated, which npm rejects with a 404.
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_token }}


### PR DESCRIPTION
## Problem
Publishing failed with:
```
error Couldn't publish package: "https://registry.npmjs.org/twzipcode-vue: Not found"
```

## Diagnosis
A 404 when publishing an **existing public package** means authentication never reached npm — npm returns 404 (not 401) for unauthenticated writes so it doesn't leak whether a package exists. Confirmed against the registry:
- `twzipcode-vue` exists publicly (latest `2.2.2`).
- `3.0.0` is not yet published, so this was a real auth failure, not a duplicate-version rejection.

The root cause: **`yarn publish` (classic) does not read `NODE_AUTH_TOKEN`** from the `.npmrc` that `actions/setup-node` generates (`//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`). That `.npmrc` mechanism is designed for `npm`. So `yarn publish` ran unauthenticated → 404.

## Fix
Switch the publish step from `yarn publish` to `npm publish`, which consumes the generated `.npmrc` token correctly. `prepublishOnly` still runs the full gate (lint + test + smoke + build) regardless of the client.

## Verification
- `npm pack --dry-run` confirms the publish tarball is correct: `dist/` + `src/components` + `src/index.js` (demo excluded, per the `files` whitelist).
- YAML validated.

## Note
The publish job runs on tag pushes (`refs/tags/*`). After merging, push a `v3.0.0` tag to release. Make sure the `npm_token` secret is a current **Automation** token with publish rights.

---
_Generated by [Claude Code](https://claude.ai/code/session_015v4d4Sqaf4JHCA9S9bGjGq)_